### PR TITLE
remove uneeded setting of RBENV_ROOT

### DIFF
--- a/rbenv.fish
+++ b/rbenv.fish
@@ -1,6 +1,5 @@
 function init --on-event init_rbenv
-  set -gx PATH "$HOME/.rbenv/bin" "$HOME/.rbenv/shims" $PATH
-  set -gx RBENV_SHELL fish
+  set -x RBENV_SHELL fish
   if status --is-interactive
     source (rbenv init - | psub)
   end


### PR DESCRIPTION
I looked further and as it turns out:
```fish
set -gx PATH "$HOME/.rbenv/bin" "$HOME/.rbenv/shims" $PATH
```

is not really needed because `source (rbenv init - | psub)` already searches those locations automatically if `RBENV_ROOT` is not set (which is the default unless you want to set custom `bin` and `shims` directory).

Also, is not necessary to modify `$PATH` as that is the responsibility of the user IMO. If you installed rbenv with `homebrew`, paths are already symlinked correctly, otherwise you need to add it manually in your dotfiles.